### PR TITLE
fix: Update module version and adjust repository path for PowerShell scripts

### DIFF
--- a/OSD.Workspace.psd1
+++ b/OSD.Workspace.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSD.Workspace.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.4.21.1'
+ModuleVersion = '25.4.23.1'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/private/steps/Step-BuildMediaPowerShellUpdate.ps1
+++ b/private/steps/Step-BuildMediaPowerShellUpdate.ps1
@@ -58,7 +58,7 @@ HKLM,"SYSTEM\ControlSet001\Control\Session Manager\Environment",LOCALAPPDATA,0x0
     $null = robocopy.exe "$MountPath\Users\Default" "$MountPath\Windows\System32\Config\SystemProfile" *.* /e /b /ndl /nfl /np /ts /r:0 /w:0 /xj /xf NTUSER.*
     #=================================================
     # Get the Paths for this function
-    $WinPEPSRepository = "$MountPath\psrepository"
+    $WinPEPSRepository = "$MountPath\Windows\Temp\psrepository"
     $CachePSRepository = $OSDWorkspace.paths.psrepository
     $CachePowerShellModules = $OSDWorkspace.paths.powershell_modules
     $MountedPSModulesPath = "$MountPath\Program Files\WindowsPowerShell\Modules"


### PR DESCRIPTION
- Updated the module version in OSD.Workspace.psd1 from '25.4.21.1' to '25.4.23.1' to reflect the latest changes.
- Modified the path for the PowerShell repository in Step-BuildMediaPowerShellUpdate.ps1 from "$MountPath\psrepository" to "$MountPath\Windows\Temp\psrepository" for improved organization.

These changes enhance the module's versioning and ensure the correct repository path is used during execution.