### PR TITLE
fix: Correct foreground color in logging output for image index display in Get-PSDriveWindowsImageIndex function

### DIFF
--- a/private/import/Get-PSDriveWindowsImageIndex.ps1
+++ b/private/import/Get-PSDriveWindowsImageIndex.ps1
@@ -25,7 +25,7 @@ function Get-PSDriveWindowsImageIndex {
             Get-WindowsImage -ImagePath "$($_.FullName)"
         } | ForEach-Object {
             Get-WindowsImage -ImagePath "$($_.ImagePath)" -Index $($_.ImageIndex) | Select-Object -Property @{Name = 'MediaRoot'; Expression = { $MediaRoot } }, *
-            Write-Host -ForegroundColor Gray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] ImageIndex $($_.ImageIndex): $($_.ImageName)" -ForegroundColor DarkGray
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] ImageIndex $($_.ImageIndex): $($_.ImageName)"
         }
 
         # Set Architecture to human readable"


### PR DESCRIPTION
Updated the Write-Host command to ensure consistent foreground color for logging image index information. This change enhances readability of log messages during the execution of the Get-PSDriveWindowsImageIndex function.