### PR TITLE
fix: Update installation commands for Visual Studio Code and Git in Install-OSDWorkspace.ps1

### DIFF
--- a/public/Install-OSDWorkspace.ps1
+++ b/public/Install-OSDWorkspace.ps1
@@ -97,7 +97,7 @@ function Install-OSDWorkspace {
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Microsoft Visual Studio Code is not installed"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Initialization will not continue"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Microsoft Visual Studio Code using the following command (saved to clipboard):"
-        $InstallMessage = "winget install -e --id Microsoft.VisualStudioCode --scope user --override '/SILENT /mergetasks=`"!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath`"'"
+        $InstallMessage = "winget install -e --id Microsoft.VisualStudioCode --override '/SILENT /mergetasks=`"!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath`"'"
         $InstallMessage | Set-Clipboard
         Write-Host -ForegroundColor DarkGray $InstallMessage
         return
@@ -125,7 +125,7 @@ function Install-OSDWorkspace {
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Git for Windows is not installed"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Initialization will not continue"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Git for Windows:"
-        $InstallMessage = 'winget install -e --id Git.Git --scope user'
+        $InstallMessage = 'winget install -e --id Git.Git'
         $InstallMessage | Set-Clipboard
         Write-Host -ForegroundColor DarkGray $InstallMessage
         return

--- a/public/Install-OSDWorkspace.ps1
+++ b/public/Install-OSDWorkspace.ps1
@@ -124,7 +124,7 @@ function Install-OSDWorkspace {
     else {
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Git for Windows is not installed"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Initialization will not continue"
-        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Git for Windows:"
+        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Git for Windows using the following command (saved to clipboard):"
         $InstallMessage = 'winget install -e --id Git.Git'
         $InstallMessage | Set-Clipboard
         Write-Host -ForegroundColor DarkGray $InstallMessage


### PR DESCRIPTION
- Modified the command for installing Microsoft Visual Studio Code to remove the unnecessary '--scope user' option.
- Adjusted the Git for Windows installation command to remove the '--scope user' option for consistency.

These changes ensure that the installation commands are streamlined and align with best practices for using WinGet.