### PR TITLE
fix: Update Visual Studio Code and Git installation instructions in Install-OSDWorkspace.ps1

### DIFF
--- a/public/Install-OSDWorkspace.ps1
+++ b/public/Install-OSDWorkspace.ps1
@@ -96,10 +96,10 @@ function Install-OSDWorkspace {
     else {
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Microsoft Visual Studio Code is not installed"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Initialization will not continue"
-        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Microsoft Visual Studio Code using the following command (saved to clipboard):"
-        $InstallMessage = "winget install -e --id Microsoft.VisualStudioCode --override '/SILENT /mergetasks=`"!runcode,addcontextmenufiles,addcontextmenufolders,associatewithfiles,addtopath`"'"
-        $InstallMessage | Set-Clipboard
-        Write-Host -ForegroundColor DarkGray $InstallMessage
+        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] See the below Wiki for instructions on how to install Visual Studio Code (Url copied to clipboard):"
+        $WikiUrl = "https://github.com/OSDeploy/OSD.Workspace/wiki/Microsoft-Visual-Studio-Code"
+        $WikiUrl | Set-Clipboard
+        Write-Host -ForegroundColor DarkGray $WikiUrl
         return
     }
     #=================================================
@@ -124,10 +124,10 @@ function Install-OSDWorkspace {
     else {
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Git for Windows is not installed"
         Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Initialization will not continue"
-        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Use WinGet to install Git for Windows using the following command (saved to clipboard):"
-        $InstallMessage = 'winget install -e --id Git.Git'
-        $InstallMessage | Set-Clipboard
-        Write-Host -ForegroundColor DarkGray $InstallMessage
+        Write-Warning "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] See the below Wiki for instructions on how to install Git for Windows (Url copied to clipboard):"
+        $WikiUrl = "https://github.com/OSDeploy/OSD.Workspace/wiki/Git-for-Windows"
+        $WikiUrl | Set-Clipboard
+        Write-Host -ForegroundColor DarkGray $WikiUrl
         return
     }
     #=================================================


### PR DESCRIPTION
- Changed the warning messages for missing Visual Studio Code and Git for Windows to direct users to the Wiki for installation instructions.
- Copied the Wiki URLs to the clipboard for easy access.

This improves user experience by providing a centralized location for installation guidance.

![image](https://github.com/user-attachments/assets/ec0da7c5-8d71-41a4-9e8c-574a6b0392b6)

![image](https://github.com/user-attachments/assets/f6f123fb-cec0-48fe-9c86-d80dc8653985)


