### PR TITLE
chore: Update module version and enhance task definitions

### DIFF
--- a/OSD.Workspace.psd1
+++ b/OSD.Workspace.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSD.Workspace.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.6.15.1'
+ModuleVersion = '25.6.15.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/core/OSD.code-workspace
+++ b/core/OSD.code-workspace
@@ -103,7 +103,7 @@
     "version": "2.0.0",
     "tasks": [
       {
-        "label": "Build: Select an imported WinRE and create a WinPE build",
+        "label": "Build: Select an imported WinRE and build WinPE (en-US)",
         "command": "pwsh",
         "type": "shell",
         "windows": {

--- a/core/tasks.json
+++ b/core/tasks.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build: Select an imported WinRE and build WinPE (de-DE)",
+      "command": "pwsh",
+      "type": "shell",
+      "windows": {
+        "command": "Start-Process",
+        "args": [
+          "pwsh",
+          "-Verb",
+          "RunAs",
+          "-ArgumentList",
+          "'-NoExit -Command Build-OSDWorkspaceWinPE -Languages de-de -SetAllIntl de-de -SetInputLocale de-de'"
+        ]
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build: Select an imported WinRE and build WinPE (en-GB)",
+      "command": "pwsh",
+      "type": "shell",
+      "windows": {
+        "command": "Start-Process",
+        "args": [
+          "pwsh",
+          "-Verb",
+          "RunAs",
+          "-ArgumentList",
+          "'-NoExit -Command Build-OSDWorkspaceWinPE -Languages en-gb -SetAllIntl en-gb -SetInputLocale en-GB'"
+        ]
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build: Select an imported WinRE and build WinPE (fr-FR)",
+      "command": "pwsh",
+      "type": "shell",
+      "windows": {
+        "command": "Start-Process",
+        "args": [
+          "pwsh",
+          "-Verb",
+          "RunAs",
+          "-ArgumentList",
+          "'-NoExit -Command Build-OSDWorkspaceWinPE -Languages fr-fr -SetAllIntl fr-fr -SetInputLocale fr-fr'"
+        ]
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/public/Install-OSDWorkspace.ps1
+++ b/public/Install-OSDWorkspace.ps1
@@ -221,19 +221,19 @@ function Install-OSDWorkspace {
     # Add .gitattributes
     $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\gitattributes.txt" -Raw
     $Path = "$OSDWorkspacePath\.gitattributes"
-    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Adding $Path"
+    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Creating $Path"
     Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
     #=================================================
     # Add .gitignore
     $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\gitignore.txt" -Raw
     $Path = "$OSDWorkspacePath\.gitignore"
-    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Adding $Path"
+    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Creating $Path"
     Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
     #=================================================
     # Add or update copilot-instructions.md
     $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\copilot-instructions.md" -Raw
     $Path = "$OSDWorkspacePath\.github\copilot-instructions.md"
-    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Adding $Path"
+    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Creating $Path"
     Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
     #=================================================
     # Update Content in the registry
@@ -243,23 +243,6 @@ function Install-OSDWorkspace {
     #=================================================
     # Add or update Update-OSDWorkspaceHelp.ps1
     Update-OSDWorkspaceHelp -Force
-    #=================================================
-    # Add tasks.json
-    <#
-    $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\tasks.json" -Raw
-    $Path = "$OSDWorkspacePath\.vscode\tasks.json"
-    if (-not (Test-Path -Path $Path)) {
-        Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Adding $Path"
-        Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
-        
-        # Set the value in the registry
-        $RegName = 'tasks.json'
-        if (-not (Get-ItemProperty $RegKey -Name $RegName -ErrorAction SilentlyContinue)) {
-            try { New-ItemProperty -Path $RegKey -Name $RegName -Value $RegValue -Force | Out-Null }
-            catch {}
-        }
-    }
-    #>
     #=================================================
     # Update Default Library
     $LibraryDefaultPath = $OSDWorkspace.paths.library_default
@@ -280,10 +263,18 @@ function Install-OSDWorkspace {
         New-Item -Path "$LibraryDefaultPath\winpe-mediascript" -ItemType Directory -Force | Out-Null
     }
     #=================================================
+    # Add tasks.json
+    $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\tasks.json" -Raw
+    $Path = "$OSDWorkspacePath\.vscode\tasks.json"
+    if (-not (Test-Path -Path $Path)) {
+        Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Creating $Path"
+        Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
+    }
+    #=================================================
     # Add OSD.code-workspace
     $Content = Get-Content -Path "$($MyInvocation.MyCommand.Module.ModuleBase)\core\OSD.code-workspace" -Raw
     $Path = "$OSDWorkspacePath\OSD.code-workspace"
-    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Adding $Path"
+    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] Creating $Path"
     Set-Content -Path $Path -Value $Content -Encoding UTF8 -Force
     Write-Host -ForegroundColor Cyan "[$(Get-Date -format G)] [$($MyInvocation.MyCommand.Name)] In Windows Explorer, open the file C:\OSDWorkspace\OSD.code-workspace"
     #=================================================


### PR DESCRIPTION
- Updated ModuleVersion in OSD.Workspace.psd1 from '25.6.15.1' to '25.6.15.2'.
- Modified task label in OSD.code-workspace for clarity: changed from "Build: Select an imported WinRE and create a WinPE build" to "Build: Select an imported WinRE and build WinPE (en-US)".
- Added new tasks.json file with multiple build tasks for different languages (en-GB, de-DE, fr-FR) to streamline the build process.
- Improved logging messages in Install-OSDWorkspace.ps1 to reflect 'Creating' instead of 'Adding' for better clarity.