### PR TITLE
chore: Update module version and enhance language settings in scripts

### DIFF
--- a/OSD.Workspace.psd1
+++ b/OSD.Workspace.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSD.Workspace.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.6.15.2'
+ModuleVersion = '25.6.16.1'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/core/OSD.code-workspace
+++ b/core/OSD.code-workspace
@@ -113,7 +113,7 @@
             "-Verb",
             "RunAs",
             "-ArgumentList",
-            "'-NoExit -Command Build-OSDWorkspaceWinPE'"
+            "'-NoExit -Command Build-OSDWorkspaceWinPE -Languages en-us -SetAllIntl en-us -SetInputLocale en-us'"
           ]
         },
         "group": {
@@ -245,7 +245,7 @@
         }
       },
       {
-        "label": "Windows Sources: Import a Windows 11 Operating System and Recovery Environment",
+        "label": "Windows Sources: Import a Windows 11 OS and WinRE",
         "type": "shell",
         "command": "Start-Process",
         "args": [

--- a/public/Build-OSDWorkspaceWinPE.ps1
+++ b/public/Build-OSDWorkspaceWinPE.ps1
@@ -81,10 +81,10 @@ function Build-OSDWorkspaceWinPE {
         [System.String]
         $Architecture,
 
-        # Windows ADK Languages to add to the BootImage. Default is en-US.
+        # Windows ADK Languages to add to the BootImage. Default is en-us.
         [ValidateSet (
             '*','ar-sa','bg-bg','cs-cz','da-dk','de-de','el-gr',
-            'en-gb','es-es','es-mx','et-ee','fi-fi',
+            'en-gb','en-us','es-es','es-mx','et-ee','fi-fi',
             'fr-ca','fr-fr','he-il','hr-hr','hu-hu','it-it',
             'ja-jp','ko-kr','lt-lt','lv-lv','nb-no','nl-nl',
             'pl-pl','pt-br','pt-pt','ro-ro','ru-ru','sk-sk',
@@ -92,15 +92,15 @@ function Build-OSDWorkspaceWinPE {
             'uk-ua','zh-cn','zh-tw'
         )]
         [System.String[]]
-        $Languages = 'en-US',
+        $Languages = 'en-us',
 
         # Sets all International settings in WinPE to the specified language. Default is en-US.
         [System.String]
-        $SetAllIntl = 'en-US',
+        $SetAllIntl = 'en-us',
 
         # Sets the default InputLocale in WinPE to the specified Input Locale. Default is en-US.
         [System.String]
-        $SetInputLocale = 'en-US',
+        $SetInputLocale = 'en-us',
 
         # Set the WinPE SetTimeZone. Default is the current SetTimeZone.
         [ValidateScript( {


### PR DESCRIPTION
- Updated ModuleVersion in OSD.Workspace.psd1 from '25.6.15.2' to '25.6.16.1'.
- Modified Build-OSDWorkspaceWinPE.ps1 to standardize language parameters to 'en-us'.
- Updated OSD.code-workspace to include additional language options in task commands.

These changes improve consistency in language settings across the workspace and ensure the latest module version is reflected.