### PR TITLE
fix: Update command to force submodule update in OSD.code-workspace

### DIFF
--- a/core/OSD.code-workspace
+++ b/core/OSD.code-workspace
@@ -236,7 +236,7 @@
           "-Verb",
           "RunAs",
           "-ArgumentList",
-          "'-NoExit -Command Update-OSDWorkspaceSubmodule'"
+          "'-NoExit -Command Update-OSDWorkspaceSubmodule -Force'"
         ],
         "problemMatcher": [],
         "presentation": {


### PR DESCRIPTION
When running the task "Library Submodules: Update a Library Submodule" I received this error

[9/20/2025 8:56:37 AM] [Update-OSDWorkspaceSubmodule] OSDWorkspace: C:\OSDWorkspace
WARNING: [9/20/2025 8:56:37 AM] [Update-OSDWorkspaceSubmodule] This command will update this Git repository to the latest GitHub commit in the main branch using git fetch.
WARNING: [9/20/2025 8:56:37 AM] [Update-OSDWorkspaceSubmodule] Use the -Force switch when running this command.

This PR is adding the -Force to that task.  